### PR TITLE
Take any 2xx request as successful

### DIFF
--- a/example/bundle.js
+++ b/example/bundle.js
@@ -420,14 +420,14 @@ var FileUploadProgress = function (_React$Component) {
       req.addEventListener('load', function (e) {
         _this2.proxy.removeAllListeners(['abort']);
         var newState = { progress: 100 };
-        if (req.status !== 200) {
+        if (req.status >= 200 || req.status <= 299) {
+          _this2.setState(newState, function () {
+            _this2.props.onLoad(e, req);
+          });
+        } else {
           newState.hasError = true;
           _this2.setState(newState, function () {
             _this2.props.onError(e, req);
-          });
-        } else {
-          _this2.setState(newState, function () {
-            _this2.props.onLoad(e, req);
           });
         }
       }, false);

--- a/lib/components/FileUploadProgress.js
+++ b/lib/components/FileUploadProgress.js
@@ -136,14 +136,14 @@ var FileUploadProgress = function (_React$Component) {
       req.addEventListener('load', function (e) {
         _this2.proxy.removeAllListeners(['abort']);
         var newState = { progress: 100 };
-        if (req.status !== 200) {
+        if (req.status >= 200 && req.status <= 299) {
+          _this2.setState(newState, function () {
+            _this2.props.onLoad(e, req);
+          });
+        } else {
           newState.hasError = true;
           _this2.setState(newState, function () {
             _this2.props.onError(e, req);
-          });
-        } else {
-          _this2.setState(newState, function () {
-            _this2.props.onLoad(e, req);
           });
         }
       }, false);

--- a/src/components/FileUploadProgress.js
+++ b/src/components/FileUploadProgress.js
@@ -102,14 +102,14 @@ class FileUploadProgress extends React.Component {
     req.addEventListener('load', (e) =>{
       this.proxy.removeAllListeners(['abort']);
       let newState = {progress: 100};
-      if (req.status !== 200) {
+      if (req.status >= 200 && req.status <= 299) {
+        this.setState(newState, () => {
+          this.props.onLoad(e, req);
+        });
+      } else {
         newState.hasError = true;
         this.setState(newState, () => {
           this.props.onError(e, req);
-        });
-      } else {
-        this.setState(newState, () => {
-          this.props.onLoad(e, req);
         });
       }
     }, false);


### PR DESCRIPTION
Successful requests can have any [HTTP Status code](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html) on the 200s. 201 and 202 are pretty common codes.

Only requests status 200 is allowed right now, treating any other 2xx as an error.

This PR fixes this.